### PR TITLE
fix: preserve non-ASCII characters in CSV output

### DIFF
--- a/ADACLScan.ps1
+++ b/ADACLScan.ps1
@@ -12773,14 +12773,14 @@ Function Get-Perm {
                 } else {
                     if ($bolCMD) {
                         if ($bolToFile) {
-                            $global:ArrayAllACE | Export-Csv -Path $strFileCSV -NoTypeInformation -NoClobber
+                            $global:ArrayAllACE | Export-Csv -Path $strFileCSV -NoTypeInformation -NoClobber -Encoding UTF8
                             Write-Host "Report saved in: $strFileCSV" -ForegroundColor Yellow
                             Write-Output $strFileCSV
                         } else {
                             $global:ArrayAllACE
                         }
                     } else {
-                        $global:ArrayAllACE | Export-Csv -Path $strFileCSV -NoTypeInformation -NoClobber
+                        $global:ArrayAllACE | Export-Csv -Path $strFileCSV -NoTypeInformation -NoClobber -Encoding UTF8
                         $global:observableCollection.Insert(0, (LogMessage -strMessage "Report saved in $strFileCSV" -strType 'Warning' -DateStamp ))
                     }
                     #If Get-Perm was called with Show then open the CSV file.
@@ -13986,14 +13986,14 @@ Function Get-PermCompare {
                             } else {
                                 if ($bolCMD) {
                                     if ($bolToFile) {
-                                        $global:ArrayAllACE | Export-Csv -Path $strFileCSV -NoTypeInformation -NoClobber
+                                        $global:ArrayAllACE | Export-Csv -Path $strFileCSV -NoTypeInformation -NoClobber -Encoding UTF8
                                         Write-Host "Report saved in: $strFileCSV" -ForegroundColor Yellow
                                         Write-Output $strFileCSV
                                     } else {
                                         $global:ArrayAllACE
                                     }
                                 } else {
-                                    $global:ArrayAllACE | Export-Csv -Path $strFileCSV -NoTypeInformation -NoClobber
+                                    $global:ArrayAllACE | Export-Csv -Path $strFileCSV -NoTypeInformation -NoClobber -Encoding UTF8
                                     $global:observableCollection.Insert(0, (LogMessage -strMessage "Report saved in $strFileCSV" -strType 'Warning' -DateStamp ))
                                 }
                                 #If Get-Perm was called with Show then open the CSV file.


### PR DESCRIPTION
## Summary
When an Active Directory object name or trustee name contains non-ASCII characters (e.g. Japanese), `ADACLScan.ps1` writes them as `?` in its CSV output (`-Output CSV`).

Example, object `OU=テスト`:

```
Before: "OU=???,DC=contoso,DC=com", ...
After:  "OU=テスト,DC=contoso,DC=com", ...
```

## Root cause
The four `Export-Csv` calls that write the standard CSV report (`$global:ArrayAllACE | Export-Csv`) don't specify `-Encoding`. The default `-Encoding` for `Export-Csv` differs by PowerShell version.

References:
- Windows PowerShell 5.1 — Default value: `ASCII`
  https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/export-csv?view=powershell-5.1
- PowerShell 7.6 — Default value: `UTF8NoBOM`
  https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/export-csv?view=powershell-7.6

Because AD ACL Scanner runs on Windows PowerShell 5.1, the default is `ASCII`, which cannot represent non-ASCII characters, so they are written as `?`.

## Fix
Add `-Encoding UTF8` to the four standard-CSV `Export-Csv` calls (`$global:ArrayAllACE | Export-Csv`) in `ADACLScan.ps1`. `UTF8` is a valid value on both Windows PowerShell 5.1 and PowerShell 7+. This also matches the encoding already used by the script's other CSV writers (`Write-PermCSV` and `Write-DefSDPermCSV` already pass `-Encoding UTF8`). The CSVTEMPLATE, HTML, and EXCEL output paths are not affected.

## Testing
Ran `.\ADACLScan.ps1 -Base "OU=テスト,DC=contoso,DC=com" -Output CSV -OutputFolder .` on Windows PowerShell 5.1 against an object whose name includes Japanese characters. Before the change the name was written as `?`; after the change the CSV preserves the characters correctly.
